### PR TITLE
Fixed README.md formatting mistakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ Fakeplayer    | Default | Description
 
 Fakeplayer              | Description
 ----------------------- | -----------
-`$baseline              | Alternating flag determing whether hooks should be run.
+`$baseline`             | Alternating flag determing whether hooks should be run.
 `$base_iters`           | The total number of baseline iterations, over the course of the benchmark.
 `$base_iters_per_tick`  | The average number of baseline iterations per tick, over the course of the benchmark.
-`$benchtime             | A copy of the configuration value for use during the current benchmark.
+`$benchtime`            | A copy of the configuration value for use during the current benchmark.
 `$current_iters`        | The number of iterations, over the course of the current tick.
 `$hook_iters`           | The total number of hook iterations, over the course of the benchmark.
 `$hook_iters_per_tick`  | The average number of hook iterations per tick, over the course of the benchmark.


### PR DESCRIPTION
I spotted these when reading the README file and thought they should probably be fixed _(unless these are intentional)_.